### PR TITLE
fix(ui): enforce en-US locale for number formatting in stats displays…

### DIFF
--- a/packages/cli/src/ui/components/ModelStatsDisplay.tsx
+++ b/packages/cli/src/ui/components/ModelStatsDisplay.tsx
@@ -117,7 +117,7 @@ export const ModelStatsDisplay: React.FC = () => {
       <StatRow title="API" values={[]} isSection />
       <StatRow
         title="Requests"
-        values={getModelValues((m) => m.api.totalRequests.toLocaleString())}
+        values={getModelValues((m) => m.api.totalRequests.toLocaleString('en-US'))}
       />
       <StatRow
         title="Errors"
@@ -129,7 +129,7 @@ export const ModelStatsDisplay: React.FC = () => {
                 m.api.totalErrors > 0 ? Colors.AccentRed : Colors.Foreground
               }
             >
-              {m.api.totalErrors.toLocaleString()} ({errorRate.toFixed(1)}%)
+              {m.api.totalErrors.toLocaleString('en-US')} ({errorRate.toFixed(1)}%)
             </Text>
           );
         })}
@@ -150,14 +150,14 @@ export const ModelStatsDisplay: React.FC = () => {
         title="Total"
         values={getModelValues((m) => (
           <Text color={Colors.AccentYellow}>
-            {m.tokens.total.toLocaleString()}
+            {m.tokens.total.toLocaleString('en-US')}
           </Text>
         ))}
       />
       <StatRow
         title="Prompt"
         isSubtle
-        values={getModelValues((m) => m.tokens.prompt.toLocaleString())}
+        values={getModelValues((m) => m.tokens.prompt.toLocaleString('en-US'))}
       />
       {hasCached && (
         <StatRow
@@ -167,7 +167,7 @@ export const ModelStatsDisplay: React.FC = () => {
             const cacheHitRate = calculateCacheHitRate(m);
             return (
               <Text color={Colors.AccentGreen}>
-                {m.tokens.cached.toLocaleString()} ({cacheHitRate.toFixed(1)}%)
+                {m.tokens.cached.toLocaleString('en-US')} ({cacheHitRate.toFixed(1)}%)
               </Text>
             );
           })}
@@ -177,20 +177,20 @@ export const ModelStatsDisplay: React.FC = () => {
         <StatRow
           title="Thoughts"
           isSubtle
-          values={getModelValues((m) => m.tokens.thoughts.toLocaleString())}
+          values={getModelValues((m) => m.tokens.thoughts.toLocaleString('en-US'))}
         />
       )}
       {hasTool && (
         <StatRow
           title="Tool"
           isSubtle
-          values={getModelValues((m) => m.tokens.tool.toLocaleString())}
+          values={getModelValues((m) => m.tokens.tool.toLocaleString('en-US'))}
         />
       )}
       <StatRow
         title="Output"
         isSubtle
-        values={getModelValues((m) => m.tokens.candidates.toLocaleString())}
+        values={getModelValues((m) => m.tokens.candidates.toLocaleString('en-US'))}
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/Stats.tsx
+++ b/packages/cli/src/ui/components/Stats.tsx
@@ -47,8 +47,8 @@ export const StatsColumn: React.FC<{
 }> = ({ title, stats, isCumulative = false, width, children }) => {
   const cachedDisplay =
     isCumulative && stats.totalTokens > 0
-      ? `${stats.cachedTokens.toLocaleString()} (${((stats.cachedTokens / stats.totalTokens) * 100).toFixed(1)}%)`
-      : stats.cachedTokens.toLocaleString();
+      ? `${stats.cachedTokens.toLocaleString('en-US')} (${((stats.cachedTokens / stats.totalTokens) * 100).toFixed(1)}%)`
+      : stats.cachedTokens.toLocaleString('en-US');
 
   const cachedColor =
     isCumulative && stats.cachedTokens > 0 ? Colors.AccentGreen : undefined;
@@ -60,21 +60,21 @@ export const StatsColumn: React.FC<{
         {/* All StatRows below will now inherit the gap */}
         <StatRow
           label="Input Tokens"
-          value={stats.inputTokens.toLocaleString()}
+          value={stats.inputTokens.toLocaleString('en-US')}
         />
         <StatRow
           label="Output Tokens"
-          value={stats.outputTokens.toLocaleString()}
+          value={stats.outputTokens.toLocaleString('en-US')}
         />
         {stats.toolUseTokens > 0 && (
           <StatRow
             label="Tool Use Tokens"
-            value={stats.toolUseTokens.toLocaleString()}
+            value={stats.toolUseTokens.toLocaleString('en-US')}
           />
         )}
         <StatRow
           label="Thoughts Tokens"
-          value={stats.thoughtsTokens.toLocaleString()}
+          value={stats.thoughtsTokens.toLocaleString('en-US')}
         />
         {stats.cachedTokens > 0 && (
           <StatRow
@@ -93,7 +93,7 @@ export const StatsColumn: React.FC<{
         />
         <StatRow
           label="Total Tokens"
-          value={stats.totalTokens.toLocaleString()}
+          value={stats.totalTokens.toLocaleString('en-US')}
         />
         {children}
       </Box>

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -111,12 +111,12 @@ const ModelUsageTable: React.FC<{
           </Box>
           <Box width={inputTokensWidth} justifyContent="flex-end">
             <Text color={Colors.AccentYellow}>
-              {modelMetrics.tokens.prompt.toLocaleString()}
+              {modelMetrics.tokens.prompt.toLocaleString('en-US')}
             </Text>
           </Box>
           <Box width={outputTokensWidth} justifyContent="flex-end">
             <Text color={Colors.AccentYellow}>
-              {modelMetrics.tokens.candidates.toLocaleString()}
+              {modelMetrics.tokens.candidates.toLocaleString('en-US')}
             </Text>
           </Box>
         </Box>
@@ -125,7 +125,7 @@ const ModelUsageTable: React.FC<{
         <Box flexDirection="column" marginTop={1}>
           <Text>
             <Text color={Colors.AccentGreen}>Savings Highlight:</Text>{' '}
-            {totalCachedTokens.toLocaleString()} ({cacheEfficiency.toFixed(1)}
+            {totalCachedTokens.toLocaleString('en-US')} ({cacheEfficiency.toFixed(1)}
             %) of input tokens were served from the cache, reducing costs.
           </Text>
           <Box height={1} />


### PR DESCRIPTION
… (#2688)

Fixes snapshot test failures in ModelStatsDisplay, SessionSummaryDisplay, and StatsDisplay by enforcing 'en-US' locale in all number formatting, ensuring consistent output across environments.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
